### PR TITLE
added missing target to build with Yocto dunfell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1717,6 +1717,13 @@ endif
 	$(Q)$(MAKE) KBUILD_MODULES=$(if $(CONFIG_MODULES),1)   \
 	$(build)=$(build-dir) $(@:.ko=.o)
 	$(Q)$(MAKE) -f $(srctree)/scripts/Makefile.modpost
+	
+quiet_cmd_genenv = GENENV $@
+cmd_genenv = $(OBJCOPY) --dump-section .rodata.default_environment=$@ env/common.o; \
+	sed --in-place -e 's/\x00/\x0A/g' $@
+
+u-boot-initial-env: u-boot.bin
+	$(call if_changed,genenv)
 
 # Consistency checks
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Hello
Please accept this patch to make possible to build somlabs-uboot-imx with Yocto dunfell release.
New u-boot recipe inside poky requires `u-boot-initial-env` target inside Makefile