### PR TITLE
Allow to set ENV_SOURCE_FILE

### DIFF
--- a/include/configs/visionsom_6ull.h
+++ b/include/configs/visionsom_6ull.h
@@ -27,6 +27,7 @@
 #define CONFIG_MFG_ENV_SETTINGS
 #endif
 
+#ifndef CONFIG_ENV_SOURCE_FILE
 #define CONFIG_EXTRA_ENV_SETTINGS \
 	CONFIG_MFG_ENV_SETTINGS \
 	"console=ttymxc0\0" \
@@ -67,6 +68,8 @@
 		"run setrootmmc; " \
 		"run setloadmmc; " \
 	"fi; " \
+	
+#endif
 
 #define CONFIG_BOOTCOMMAND \
 	"run checkbootdev; " \


### PR DESCRIPTION
CONFIG_EXTRA_ENV_SETTINGS  and CONFIG_ENV_SOURCE_FILE cannot exists at the same time.

Setting default u-boot environment from file makes easy to override this hardcoded settings without need to patch u-boot source code.  See more here:
https://github.com/u-boot/u-boot/blob/master/doc/usage/environment.rst

Based on my example i need to set default fdt_file to "my-device.dtb" and set some other env variables like bootpart for swupdate.
I've created my custom u-boot config: my_device_defconfig with `CONFIG_ENV_SOURCE_FILE="vsom6ull"`  and env file: vsom6ull.env

Here are fragments of my **u-boot-imx_%.bbappend** file:
```
SRC_URI += "\
    file://my_device_defconfig   \
    file://vsom6ull.env \
"

do_configure:prepend() {
    # pick the first dtb file from machine and set as default in u-boot env
    DEFAULT_FDT=$(echo ${KERNEL_DEVICETREE} | cut -d ' ' -f1)
    
    echo "fdt_file=${DEFAULT_FDT}" >> ${WORKDIR}/vsom6ull.env

    cp ${WORKDIR}/my_device_defconfig   ${S}/configs
    cp ${WORKDIR}/vsom6ull.env          ${S}/board/somlabs/visionsom-6ull
}
```

I hope you will move hardcoded environment to .env files for all SomLabs boards in the future releases of u-boot bootloader.
